### PR TITLE
Issue #28: add NPE check in CpRootItem#setFileName

### DIFF
--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/data/CpRootItem.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/data/CpRootItem.java
@@ -40,8 +40,10 @@ public class CpRootItem extends CpItem implements ICpRootItem {
 	
 	@Override
 	public void setFileName(String fileName) {
-		IPath p = new Path(fileName);
-		this.fileName = p.toString();
+		if (fileName != null) {
+			IPath p = new Path(fileName);
+			this.fileName = p.toString();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fix for issue #28, added missing check for null filename.
