### PR TITLE
Fix for issue #48.

### DIFF
--- a/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProject.java
+++ b/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProject.java
@@ -154,6 +154,10 @@ public class RteProject extends PlatformObject implements IRteProject {
 		IProject project = getProject();
 		CoreModel model = CoreModel.getDefault();
 		ICProjectDescription projDes = model.getProjectDescription(project);
+		if (projDes == null) {
+			// not a MBS project
+			return;
+		}
 		if (save) {
 			saveRteStorage(projDes);
 			model.setProjectDescription(project, projDes);

--- a/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProjectUpdater.java
+++ b/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProjectUpdater.java
@@ -544,6 +544,10 @@ public class RteProjectUpdater extends WorkspaceJob {
 		}
 
 		IManagedBuildInfo buildInfo = ManagedBuildManager.getBuildInfo(project);
+		if (buildInfo == null) {
+			return;
+		}
+		
 		String[] configNames = buildInfo.getConfigurationNames();
 		for (String name : configNames) {
 			IConfiguration config = ProjectUtils.getConfiguration(project, name);

--- a/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/utils/ProjectUtils.java
+++ b/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/utils/ProjectUtils.java
@@ -344,6 +344,10 @@ public class ProjectUtils {
 		}
 		try{
 			IManagedBuildInfo buildInfo = ManagedBuildManager.getBuildInfo(project);
+			if (buildInfo == null) {
+				// not a MBS project
+				return null;
+			}
 			IConfiguration[] configs = buildInfo.getManagedProject().getConfigurations();
 			for(IConfiguration c : configs) {
 				if(c.getName().equals(name)) {
@@ -509,6 +513,10 @@ public class ProjectUtils {
 	 */
 	static public void setExcludeFromBuild(IProject project, String path, boolean bExclude) throws CoreException {
 		IManagedBuildInfo buildInfo = ManagedBuildManager.getBuildInfo(project);
+		if (buildInfo == null) {
+			// not a MBS project
+			return;
+		}
 		IConfiguration activeConfig = buildInfo.getDefaultConfiguration();
 		ICSourceEntry[] sourceEntries = activeConfig.getSourceEntries();
 		sourceEntries = CDataUtil.setExcluded(new Path(path), false, bExclude, sourceEntries);
@@ -523,6 +531,10 @@ public class ProjectUtils {
 	 */
 	static public boolean isExcludedFromBuild(IProject project, String path) {
 		IManagedBuildInfo buildInfo = ManagedBuildManager.getBuildInfo(project);
+		if (buildInfo == null) {
+			// not a MBS project
+			return false;
+		}
 		IConfiguration activeConfig = buildInfo.getDefaultConfiguration();
 		ICSourceEntry[] sourceEntries = activeConfig.getSourceEntries();
 		return CDataUtil.isExcluded(new Path(path), sourceEntries);


### PR DESCRIPTION
This fix allows non-MBS projects to be used as RTE projects, by
checking if ManagedBuildManager.getBuildInfo(project) returns null.