### PR TITLE
Add NPE check for non-MBS projects

### DIFF
--- a/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProjectUpdater.java
+++ b/com.arm.cmsis.pack.project/src/com/arm/cmsis/pack/project/RteProjectUpdater.java
@@ -122,8 +122,10 @@ public class RteProjectUpdater extends WorkspaceJob {
 			if (projectStorage != null) {
 				// obtain toolchain adaper its RTE options from active configuration 
 				 toolChainAdapter = projectStorage.getToolChainAdapter();
-				 IConfiguration activeConfig = ProjectUtils.getDefaultConfiguration(project);
-				 rteOptionsFromToolchain = toolChainAdapter.getRteOptions(activeConfig);
+				if (toolChainAdapter != null) {
+					IConfiguration activeConfig = ProjectUtils.getDefaultConfiguration(project);
+					rteOptionsFromToolchain = toolChainAdapter.getRteOptions(activeConfig);
+				}
 			}
 			
 			if (bLoadConfigs) {


### PR DESCRIPTION
These project do not have a toolchain adapter, so the getToolChainAdapter() method will return null. I didn't see this particular case when I tested by original fix.
