### PR TITLE
Fix for issue #60: customize perspective switch after copy example

### DIFF
--- a/com.arm.cmsis.pack.installer.ui/src/com/arm/cmsis/pack/installer/ui/PackInstallerViewController.java
+++ b/com.arm.cmsis.pack.installer.ui/src/com/arm/cmsis/pack/installer/ui/PackInstallerViewController.java
@@ -11,6 +11,8 @@
 
 package com.arm.cmsis.pack.installer.ui;
 
+import java.util.Optional;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdaptable;
@@ -188,11 +190,15 @@ public class PackInstallerViewController extends RteEventProxy implements ISelec
 			return;
 		}
 
+		Optional<String> perspectiveId = envProvider.getCopyExamplePerspectiveSwitchId();
+		if (!perspectiveId.isPresent())
+		    return;
+		        
 		IWorkbench wb = PlatformUI.getWorkbench();
 		if (wb != null) {
 			IWorkbenchWindow window = wb.getActiveWorkbenchWindow();
 			if (window != null) {
-				IPerspectiveDescriptor persDescription = wb.getPerspectiveRegistry().findPerspectiveWithId("org.eclipse.cdt.ui.CPerspective"); //$NON-NLS-1$
+				IPerspectiveDescriptor persDescription = wb.getPerspectiveRegistry().findPerspectiveWithId(perspectiveId.get());
 				IWorkbenchPage page = window.getActivePage();
 				if (page != null && persDescription != null) {
 					page.setPerspective(persDescription);

--- a/com.arm.cmsis.pack/META-INF/MANIFEST.MF
+++ b/com.arm.cmsis.pack/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CMSIS Pack
 Bundle-SymbolicName: com.arm.cmsis.pack;singleton:=true
-Bundle-Version: 2.3.1.qualifier
+Bundle-Version: 2.3.2.qualifier
 Bundle-Activator: com.arm.cmsis.pack.CpPlugIn
 Bundle-Vendor: ARM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/ICpEnvironmentProvider.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/ICpEnvironmentProvider.java
@@ -11,6 +11,8 @@
 
 package com.arm.cmsis.pack;
 
+import java.util.Optional;
+
 import org.eclipse.core.runtime.IAdaptable;
 
 import com.arm.cmsis.pack.build.IBuildSettings;
@@ -81,6 +83,17 @@ public interface ICpEnvironmentProvider extends IRteEventListener, IAdaptable {
 	 * @return the adaptable object that is created from the example, for instance IProject
 	 */
 	IAdaptable copyExample(ICpExample example);
+
+    /**
+     * Returns an optional id of a perspective to switch to after copying an
+     * example.
+     * 
+     * @return An optional containing a perspective id.
+     * @since 2.3.2
+     */
+    default Optional<String> getCopyExamplePerspectiveSwitchId() {
+        return Optional.of("org.eclipse.cdt.ui.CPerspective");
+    }
 
 	/**
 	 * Adjusts build settings every time RTE changes


### PR DESCRIPTION
This is a suggested fix for issue #60 where we add a default method in the `ICpEnvironmentProvider` interface allowing environment providers to customize the perspective id to use (if any) after copying an example.