### PR TITLE
Requesting changes.

### DIFF
--- a/com.arm.cmsis.config/META-INF/MANIFEST.MF
+++ b/com.arm.cmsis.config/META-INF/MANIFEST.MF
@@ -16,3 +16,6 @@ Require-Bundle: org.eclipse.ui,
  com.arm.cmsis.pack.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
+Export-Package: com.arm.cmsis.config.model,
+ com.arm.cmsis.parser,
+ com.arm.cmsis.utils

--- a/com.arm.cmsis.config/src/com/arm/cmsis/parser/ConfigWizardParser.java
+++ b/com.arm.cmsis.config/src/com/arm/cmsis/parser/ConfigWizardParser.java
@@ -65,7 +65,8 @@ public class ConfigWizardParser {
 
 	private TreeMap<Integer, String> fCommentContainer; // offset->string
 
-	String fParsingErrorMessage;
+	String fParsingErrorMessage = null;
+    private boolean showErrorDialog = true;
 
 	/**
 	 * Parser for the config wizard
@@ -103,6 +104,23 @@ public class ConfigWizardParser {
 		clear();
 		setParseRange(0, fDocument.getLength());
 		return doParse();
+	}
+
+	/**
+	 * Control the appears of the MessageDialog for parse errors.
+	 * Defaults to {@code true}.
+	 */
+	public void setShowErrorDialog(boolean show) {
+        this.showErrorDialog = show;
+    }
+	
+	/**
+	 * Return the parsing error message.  Note: callers should rely on
+	 * the {@link #parse()} method to determine the valid nature of the
+	 * parsing.
+     */
+    public String getParsingErrorMessage() {
+        return fParsingErrorMessage;
 	}
 
 	public boolean findConfigurationWizard() {
@@ -676,6 +694,7 @@ public class ConfigWizardParser {
 	protected void syntaxError() {
 		fParsingErrorOffset = fScanner.getTokenOffset();
 		int line = fScanner.getCurrentLineNumber();
+		if (showErrorDialog)
 		Display.getDefault().asyncExec(() -> MessageDialog.openError(Display.getDefault().getActiveShell(),
 				Messages.ConfigWizardParser_ErrorInConfigWizard,
 				Messages.ConfigWizardParser_SyntaxErrorAtLine + (line + 1) + ": " + fParsingErrorMessage)); //$NON-NLS-1$

--- a/com.arm.cmsis.config/src/com/arm/cmsis/parser/ConfigWizardScanner.java
+++ b/com.arm.cmsis.config/src/com/arm/cmsis/parser/ConfigWizardScanner.java
@@ -199,10 +199,10 @@ public class ConfigWizardScanner extends RuleBasedScanner {
 			if (CONFIG_STRING.equals(getTokenTag(token))) {
 				return text;
 			} else if (CONFIG_MARK.equals(getTokenTag(token))) {
-				return text.trim().replaceAll("\\s+"," "); //$NON-NLS-1$ //$NON-NLS-2$
+				return usePattern(ExtraWhitespacePattern, text.trim(), " "); //$NON-NLS-1$ 
 			} else {
 				// Get the pure text in the <>
-				return text.replaceAll("[\\s<>]",""); //$NON-NLS-1$ //$NON-NLS-2$
+				return usePattern(WhitespaceAndDelimitersPattern, text, ""); //$NON-NLS-1$ 
 			}
 		} catch (BadLocationException e) {
 		}
@@ -210,6 +210,13 @@ public class ConfigWizardScanner extends RuleBasedScanner {
 		return null;
 	}
 
+    static Pattern ExtraWhitespacePattern = Pattern.compile("\\s+");  //$NON-NLS-1$ 
+    static Pattern WhitespaceAndDelimitersPattern = Pattern.compile("[\\s<>]");  //$NON-NLS-1$ 
+	static String usePattern(Pattern p, String str, String replacement)
+	{
+	    return p.matcher(str).replaceAll(replacement);
+	}
+	
 	public ETokenType getTokenType(IToken token) {
 		if (token.isEOF()) {
 			return ETokenType.EOC;


### PR DESCRIPTION
1) Manifest.mf change will allow creation of an editor in a package other than com.arm.cmsis.config
2) Parser change allows a client to control whether the dialog appears on a parser error
3) Scanner change provides a performance improvement for a client scanning 100's of header files

Change 1 allows us to create a new UI on top of the data provided by the parser.
Change 2 allows us to provide a headless client which parses a folder of header files and generates a report of parsing errors.
Change 3 provides an improvement which makes little difference when scanning a single header for an editor, but makes a large difference when scanning 100's of files.