### PR TITLE
Adding support for file attribute in example project environment.

### DIFF
--- a/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/CpExample.java
+++ b/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/CpExample.java
@@ -72,7 +72,14 @@ public class CpExample extends CpItem implements ICpExample {
 		return getEnvironmentAttribute(environmentName, CmsisConstants.FOLDER);
 	}
 
-	private String getEnvironmentAttribute(String environmentName, String attributeName) {
+	/**
+	 * Fetch an attribute from the environment tag of an example project.
+	 * 
+	 * @param environmentName
+	 * @param attributeName
+	 * @return
+	 */
+	protected String getEnvironmentAttribute(String environmentName, String attributeName) {
 		if (environmentName == null)
 			return null;
 		Collection<? extends ICpItem> environments = getGrandChildren(CmsisConstants.PROJECT_TAG);

--- a/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/CpExample.java
+++ b/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/CpExample.java
@@ -64,13 +64,22 @@ public class CpExample extends CpItem implements ICpExample {
 
 	@Override
 	public String getLoadPath(String environmentName) {
-		if(environmentName == null)
+		return getEnvironmentAttribute(environmentName, CmsisConstants.LOAD);
+	}
+
+	@Override
+	public String getProjectFolder(String environmentName) {
+		return getEnvironmentAttribute(environmentName, CmsisConstants.FOLDER);
+	}
+
+	private String getEnvironmentAttribute(String environmentName, String attributeName) {
+		if (environmentName == null)
 			return null;
 		Collection<? extends ICpItem> environments = getGrandChildren(CmsisConstants.PROJECT_TAG);
 		if (environments != null) {
 			for (ICpItem environment : environments) {
-				if (environment.getName().equals(environmentName)){
-					return environment.getAttribute(CmsisConstants.LOAD);
+				if (environment.getName().equals(environmentName)) {
+					return environment.getAttribute(attributeName);
 				}
 			}
 		}

--- a/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/ICpExample.java
+++ b/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/ICpExample.java
@@ -49,4 +49,11 @@ public interface ICpExample extends ICpItem {
 	 * @return true if contains board 
 	 */
 	boolean containsBoard(String boardId);
+
+	/**
+	 * Gets the folder attribute stored in the environment tag.
+	 * @return folder in the project, or null of it does not exist.
+	 */
+	String getProjectFolder(String environmentName);
+
 }

--- a/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/ICpExample.java
+++ b/com.arm.cmsis.pack.data/src/com/arm/cmsis/pack/data/ICpExample.java
@@ -54,6 +54,8 @@ public interface ICpExample extends ICpItem {
 	 * Gets the folder attribute stored in the environment tag.
 	 * @return folder in the project, or null of it does not exist.
 	 */
-	String getProjectFolder(String environmentName);
+	default String getProjectFolder(String environmentName) {
+		return null;
+	};
 
 }

--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/ICpEnvironmentProvider.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/ICpEnvironmentProvider.java
@@ -154,6 +154,19 @@ public interface ICpEnvironmentProvider extends IRteEventListener, IAdaptable {
 			return null;
 		return getName();
 	}
+
+	/**
+	 * Gets the project folder, i.e., the folder attribute listed in the environment tag.
+	 * @param example  ICpExample to get the environment folder from.
+	 * @return the project relative path to the folder listed in the environment,
+	 *         <code>null</code> if not supported.
+	 */
+	default String getProjectFolder(ICpExample example) {
+		if (example == null)
+			return null;
+		return example.getProjectFolder(getName());
+	}
+
 	
 	/**
 	 * Contributes to newly created CMSIS RTE project. It could be an additional project nature, additional files, etc.

--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/IRteExampleItem.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/IRteExampleItem.java
@@ -94,7 +94,8 @@ public interface IRteExampleItem extends ICmsisMapItem<IRteExampleItem> {
 	 * Return the folder attribute
 	 * @return folder path, null if not supported.
 	 */
-	String getProjectFolder();
-
+	default String getProjectFolder() {
+		return null;
+	};
 
 }

--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/IRteExampleItem.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/IRteExampleItem.java
@@ -90,4 +90,11 @@ public interface IRteExampleItem extends ICmsisMapItem<IRteExampleItem> {
 	 */
 	String getLoadPath();
 
+	/**
+	 * Return the folder attribute
+	 * @return folder path, null if not supported.
+	 */
+	String getProjectFolder();
+
+
 }

--- a/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/RteExampleItem.java
+++ b/com.arm.cmsis.pack/src/com/arm/cmsis/pack/rte/examples/RteExampleItem.java
@@ -36,6 +36,7 @@ public class RteExampleItem extends CmsisMapItem<IRteExampleItem> implements IRt
 	protected Boolean fImport = null;
 	protected String fEnvironment = null;
 	protected String fLoadPath = null;
+	protected String fProjectFolder = null;
 	protected ICpPack fPack = null; // example's pack
 
 	/**
@@ -235,6 +236,15 @@ public class RteExampleItem extends CmsisMapItem<IRteExampleItem> implements IRt
 			fLoadPath = envProvider.getAbsoluteLoadPath(getExample());
 		}
 		return fLoadPath;	
+	}
+
+	@Override
+	public String getProjectFolder() {
+		if (fProjectFolder == null && isSupported()) {
+			ICpEnvironmentProvider envProvider = CpPlugIn.getEnvironmentProvider();
+			fProjectFolder = envProvider.getProjectFolder(getExample());
+		}
+		return fProjectFolder;
 	}
 
 	@Override


### PR DESCRIPTION
The file attribute in the project environment adds the metadata needed to supply compiler specific files in an example project.