### PR TITLE
Provide a CMSIS-Pack command line installer IApplication

### DIFF
--- a/com.arm.cmsis.pack.installer/plugin.xml
+++ b/com.arm.cmsis.pack.installer/plugin.xml
@@ -11,4 +11,17 @@
             name="Default CMSIS-Pack installer ">
       </PackInstaller>
    </extension>
+   <extension
+         id="com.arm.cmsis.pack.installer"
+         name="CMSIS-Pack command line installer"
+         point="org.eclipse.core.runtime.applications">
+      <application
+            cardinality="singleton-global"
+            thread="main"
+            visible="true">
+         <run
+               class="com.arm.cmsis.pack.installer.ClPackInstaller">
+         </run>
+      </application>
+   </extension>
 </plugin>

--- a/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/ClPackInstaller.java
+++ b/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/ClPackInstaller.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Analog Devices, Inc. and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Analog Devices - command line pack installer application
+ *******************************************************************************/
+
+package com.arm.cmsis.pack.installer;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+
+import com.arm.cmsis.pack.CpPlugIn;
+import com.arm.cmsis.pack.ICpPackInstaller;
+import com.arm.cmsis.pack.data.ICpPack;
+import com.arm.cmsis.pack.data.ICpPackCollection;
+import com.arm.cmsis.pack.events.IRteEventListener;
+import com.arm.cmsis.pack.events.RteEvent;
+
+/**
+ * Command line pack installer
+ *
+ */
+public class ClPackInstaller implements IApplication, IRteEventListener {
+	
+	/** true if using the command line installer */
+	private static boolean isHeadless = false;
+	
+	/** return code for errors */
+	private static final int EXIT_ERROR = 0x1;
+	
+	/** true if an error has occurred while using the installer */
+	private boolean errorOccurred = false;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Object start(IApplicationContext context) throws Exception {
+		// suppress error dialogs
+		System.setProperty(IApplicationContext.EXIT_DATA_PROPERTY, "");
+		isHeadless = true;
+		CpPlugIn.getDefault().addListener(this);
+		
+		ICpPackInstaller packInstaller = CpPlugIn.getPackManager().getPackInstaller();
+		if(packInstaller == null)
+			return -1;
+
+		boolean showUsage = false;
+		String[] args = (String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS);
+		if (args != null) {
+			for (int i=0; i<args.length; i++) {
+				String arg = args[i];
+				if (arg.equals("-importPack")) {
+					if (i+1 < args.length) {
+						String packFile = args[i+1];
+						CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_INFO, NLS.bind(Messages.CpPackInstaller_ImportingPack, packFile));
+						packInstaller.importPack(packFile);
+						i++;
+					}
+					else {
+						showUsage = true;
+					}
+				}
+				else if (arg.equals("-installPack")) {
+					if (i+1 < args.length) {
+						String packId = args[i+1];
+						// retrieve the packs from the web so we can install one of them
+						CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_INFO, Messages.ClPackInstaller_RetrievingPacks);
+						packInstaller.updatePacks(new NullProgressMonitor());
+						CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_INFO, NLS.bind(Messages.CpPackInstaller_InstallingPack, packId));
+						packInstaller.installPack(packId);
+						i++;
+					}
+					else {
+						showUsage = true;
+					}
+				}
+				else if (arg.equals("-deletePack")) {
+					if (i+1 < args.length) {
+						String packId = args[i+1];
+						CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_INFO, NLS.bind(Messages.CpPackInstaller_DeletingPack, packId));
+						ICpPackCollection packs = CpPlugIn.getPackManager().getInstalledPacks();
+						ICpPack pack = null;
+						if (packs != null) {
+							pack = packs.getPack(packId);
+							if (pack != null) {
+								packInstaller.removePack(pack, true);
+							}
+						}
+						if (packs == null || pack == null) {
+							CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_ERROR, NLS.bind(Messages.ClPackInstaller_FailToDeletePack, packId));
+						}
+						i++;
+					}
+					else {
+						showUsage = true;
+					}
+				}
+				else if (arg.equals("-help")) {
+					showUsage = true;
+					break;
+				}
+				else {
+					CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_ERROR, NLS.bind(Messages.ClPackInstaller_InvalidArg, arg));
+					showUsage = true;
+					break;
+				}
+			}
+			
+			if (showUsage) {
+				printUsage();
+			}
+		}
+		
+		// wait for all jobs to finish
+		while (packInstaller.isBusy()) {
+			// flush the display to ensure all dialogs are shown
+			if (!Display.getDefault().readAndDispatch()) {
+				Thread.sleep(100);
+			}
+		}
+		
+		if (errorOccurred) {
+			return EXIT_ERROR;
+		}
+		
+		return EXIT_OK;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void stop() {
+		CpPlugIn.getDefault().removeListener(this);
+	}
+	
+	/**
+	 * Print the usage to the console
+	 */
+	public static void printUsage() {
+		CpPlugIn.getDefault().emitRteEvent(RteEvent.PRINT_INFO, Messages.ClPackInstaller_Usage); 
+	}
+
+	/**
+	 * Returns true if using the command line installer (no UI)
+	 * 
+	 * @return true if using the command line installer, otherwise false
+	 */
+	public static boolean isHeadless() {
+		return isHeadless;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void handle(RteEvent event) {
+		switch(event.getTopic()) {
+		case RteEvent.PRINT_OUTPUT:
+		case RteEvent.PRINT_INFO:
+		case RteEvent.PRINT_WARNING:
+			System.out.println((String)event.getData());
+			break;
+		case RteEvent.PRINT_ERROR:
+			errorOccurred = true;
+			System.out.println((String)event.getData());
+			break;
+		}
+	}
+}

--- a/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/Messages.java
+++ b/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/Messages.java
@@ -7,6 +7,7 @@
 *
 * Contributors:
 * ARM Ltd and ARM Germany GmbH - Initial API and implementation
+* Analog Devices, Inc - Extension and implementation
 *******************************************************************************/
 
 package com.arm.cmsis.pack.installer;
@@ -96,6 +97,11 @@ public class Messages extends NLS {
     public static String LicenseDialog_LicenseDialogTitle;
 
     public static String PackInstallerUtils_PleaseAgreeLicenseAgreement;
+
+    public static String ClPackInstaller_FailToDeletePack;
+    public static String ClPackInstaller_InvalidArg;
+    public static String ClPackInstaller_RetrievingPacks;
+    public static String ClPackInstaller_Usage;
 
     static {
         // initialize resource bundle

--- a/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/messages.properties
+++ b/com.arm.cmsis.pack.installer/src/com/arm/cmsis/pack/installer/messages.properties
@@ -1,3 +1,7 @@
+ClPackInstaller_FailToDeletePack=Failed to delete pack {0}. Pack not found.
+ClPackInstaller_InvalidArg=Invalid arg ''{0}''.
+ClPackInstaller_RetrievingPacks=Retrieving packs from the web.
+ClPackInstaller_Usage=Usage:\n  -help                    : Print this message.\n  -importPack <.pack file> : Import a local Software Pack file. You must accept the User License Agreement if the pack contains a license.\n  -installPack <pack name> : Install a Software Pack file from the web. You must accept the User License Agreement if the pack contains a license.\n  -deletePack <pack name>  : Delete an imported or installed Software Pack file.
 CpPackJob_CancelledByUser=Cancelled by user
 CpPackImportFolderJob_ContainMorePdscFile=\ contains more than 1 pdsc file.
 CpPackImportFolderJob_ImportingPack=Importing pack {0}


### PR DESCRIPTION
A useful enhancement is our CMSIS-Pack command line installer (IApplication) that allows users to import or install a CMSIS pack file headlessly.
```
Usage:
  -help                    : Print this message.
  -importPack <.pack file> : Import a local Software Pack file. You must accept the User License Agreement if the pack contains a license.
  -installPack <pack name> : Install a Software Pack file from the web. You must accept the User License Agreement if the pack contains a license.
  -deletePack <pack name>  : Delete an imported or installed Software Pack file.
```